### PR TITLE
Fix footer colors for accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,29 +122,25 @@
     .attribution{font-size:.6em;margin-top:5px} .attribution a{color:#30997a;text-decoration:none}
     .attribution a:hover{text-decoration:underline}
 		
-		/* restore original footer colour and text */
-		footer {
-			background-color: #30997a !important;
-			color: #fff !important;
-		}
-		footer p,
-		footer .attribution,
-		footer .attribution a {
-			color: #fff !important;
-		}
-		footer img {
-			filter: none;
-		}
-		
-		/* make footer attribution the same colour as the footer background */
-		footer {
-			background-color: #30997a !important;
-		}
-		footer .attribution,
-		footer .attribution a {
-			color: #30997a !important;
-			text-decoration: none;
-		}
+                /* restore original footer colour and text */
+                footer {
+                        background-color: #30997a !important;
+                        color: #fff !important;
+                }
+                footer p,
+                footer .attribution {
+                        color: #fff !important;
+                }
+                footer .attribution a {
+                        color: #fff !important;
+                        text-decoration: underline;
+                }
+                footer .attribution a:hover {
+                        color: #fcdb92 !important;
+                }
+                footer img {
+                        filter: none;
+                }
 		
     /* Responsive adjustments */
     @media (max-width:768px){


### PR DESCRIPTION
## Summary
- remove the duplicate footer override that reset attribution text to the background color
- keep the brand footer background while giving the attribution link accessible contrast and hover styling

## Testing
- Viewed index.html in the browser

------
https://chatgpt.com/codex/tasks/task_e_68dd37f757188331bf4d2a3be72255f7