### PR TITLE
Align festival info card with artwork aspect ratio

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -44,17 +44,19 @@
     .scene {
       width: 100%;
       max-width: 720px;
-      height: calc(min(90vh, 980px));
+      max-height: 90vh;
+      aspect-ratio: 1220 / 2126;
       perspective: 1200px;
       cursor: pointer;
       display: flex;
-      align-items: center;
+      align-items: stretch;
       justify-content: center;
     }
 
     .pass {
       width: 100%;
-      height: 100%;
+      max-height: 100%;
+      aspect-ratio: inherit;
       position: relative;
       transform-style: preserve-3d;
       transition: transform 700ms cubic-bezier(.2,.9,.3,1);
@@ -164,7 +166,7 @@
     .text-frame * { user-select: text; }
 
     @media (max-width:420px) {
-      .text-frame { transform: translateY(-12%); }
+      .text-frame { transform: none; }
     }
 
     /* ===== Header / Footer styles (same as site) ===== */


### PR DESCRIPTION
## Summary
- size the festival info flip card with the poster artwork's aspect ratio instead of a fixed height
- cap the card at 90vh while keeping the existing 720px width ceiling so it scales gracefully
- drop the mobile translateY hack now that the art and textbox align naturally across viewports

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd3ef7b8348331a683549841f75e8a