### PR TITLE
Add lanyard strap presentation to festival pass

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -41,6 +41,73 @@
       padding: 12px;
     }
 
+    .lanyard {
+      position: relative;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: min(100%, 720px);
+      isolation: isolate;
+      --lanyard-drop: clamp(140px, 26vh, 240px);
+      --clip-offset: clamp(26px, 5vw, 40px);
+      --strap-width: clamp(32px, 7vw, 52px);
+    }
+
+    .lanyard-strap,
+    .lanyard-clip {
+      pointer-events: none;
+      user-select: none;
+    }
+
+    .lanyard-strap {
+      position: absolute;
+      top: calc(-1 * (var(--lanyard-drop) + var(--clip-offset)));
+      left: 50%;
+      transform: translateX(-50%);
+      width: var(--strap-width);
+      height: var(--lanyard-drop);
+      border-radius: 999px;
+      background: linear-gradient(180deg, rgba(255,255,255,0.1) 0%, rgba(23,180,173,0.92) 40%, rgba(9,94,89,0.98) 100%);
+      box-shadow: 0 16px 32px rgba(0,0,0,0.35);
+      z-index: 0;
+    }
+
+    .lanyard-strap::after {
+      content: "";
+      position: absolute;
+      inset: 10% 20%;
+      border-radius: 999px;
+      background: linear-gradient(180deg, rgba(255,255,255,0.55), rgba(255,255,255,0.05));
+      opacity: 0.75;
+    }
+
+    .lanyard-clip {
+      position: absolute;
+      top: calc(-1 * var(--clip-offset));
+      left: 50%;
+      transform: translateX(-50%);
+      width: clamp(84px, 18vw, 128px);
+      height: clamp(30px, 6vw, 46px);
+      border-radius: 14px 14px 18px 18px;
+      background: linear-gradient(180deg, #fafafa 0%, #d8d8d8 55%, #c3c3c3 100%);
+      box-shadow: 0 8px 18px rgba(0,0,0,0.28);
+      z-index: 2;
+    }
+
+    .lanyard-clip::before {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 46%;
+      transform: translate(-50%, -50%);
+      width: 70%;
+      height: 48%;
+      border-radius: 999px;
+      border: 2px solid rgba(115,115,115,0.55);
+      background: linear-gradient(180deg, rgba(240,240,240,0.75), rgba(255,255,255,0.1));
+      box-shadow: inset 0 2px 4px rgba(255,255,255,0.45);
+    }
+
     .scene {
       width: 100%;
       max-width: 720px;
@@ -51,6 +118,21 @@
       display: flex;
       align-items: stretch;
       justify-content: center;
+      position: relative;
+      z-index: 1;
+    }
+
+    @media (max-width: 600px) {
+      .lanyard {
+        --lanyard-drop: clamp(110px, 24vh, 180px);
+        --clip-offset: clamp(22px, 5.8vw, 32px);
+        --strap-width: clamp(26px, 9vw, 40px);
+      }
+
+      .lanyard-clip {
+        width: clamp(72px, 28vw, 110px);
+        height: clamp(26px, 8vw, 40px);
+      }
     }
 
     .pass {
@@ -326,8 +408,11 @@
 
   <!-- ===== original scene markup preserved exactly below, inside page-content ===== -->
   <div class="page-content">
-    <div class="scene" id="scene" tabindex="0" aria-label="Festival pass. Click to flip for more information.">
-      <div class="pass" id="pass">
+    <div class="lanyard">
+      <div class="lanyard-strap" aria-hidden="true"></div>
+      <div class="lanyard-clip" aria-hidden="true"></div>
+      <div class="scene" id="scene" tabindex="0" aria-label="Festival pass. Click to flip for more information.">
+        <div class="pass" id="pass">
 
         <section class="face front" aria-hidden="false">
           <div class="hint">Click to flip</div>
@@ -361,6 +446,7 @@
           </div>
         </section>
 
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- wrap the festival pass scene with a new lanyard container that includes strap and clip elements
- style the lanyard strap and clip so the pass appears to hang while keeping the flip interaction intact
- tune responsive CSS variables so the lanyard proportions adapt on mobile and desktop widths

## Testing
- Visual verification in Chromium (desktop and mobile viewports)


------
https://chatgpt.com/codex/tasks/task_e_68dd60ab908c8331b7eef384dfda6eb0