### PR TITLE
Adjust festival info pass text frame spacing

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -168,12 +168,12 @@
 
     .text-frame {
       position: absolute;
-      top: 34%;
-      bottom: 13%;
-      left: 25%;
-      right: 25%;
+      top: 36%;
+      bottom: 16%;
+      left: 28%;
+      right: 28%;
       overflow: hidden;
-      padding: clamp(6px, 1vw, 10px);
+      padding: clamp(8px, 1.1vw, 12px);
       border-radius: 8px;
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
       overflow-wrap: break-word;


### PR DESCRIPTION
## Summary
- increase the festival info pass text frame inset margins so copy stays within the inner rectangle
- slightly enlarge the padding clamp to maintain breathing room around the text

## Testing
- Manual verification: festival-info.html in desktop and mobile breakpoints

------
https://chatgpt.com/codex/tasks/task_e_68dd632d5ae48331b61e937dd256e2bc