### PR TITLE
Add WebKit vendor prefixes for festival pass flip

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -114,12 +114,14 @@
       max-height: 90vh;
       aspect-ratio: 1220 / 2126;
       perspective: 1200px;
+      -webkit-perspective: 1200px;
       cursor: pointer;
       display: flex;
       align-items: stretch;
       justify-content: center;
       position: relative;
       z-index: 1;
+      -webkit-transform-style: preserve-3d;
     }
 
     @media (max-width: 600px) {
@@ -141,7 +143,9 @@
       aspect-ratio: inherit;
       position: relative;
       transform-style: preserve-3d;
+      -webkit-transform-style: preserve-3d;
       transition: transform 700ms cubic-bezier(.2,.9,.3,1);
+      -webkit-transition: -webkit-transform 700ms cubic-bezier(.2,.9,.3,1);
       border-radius: 12px;
       box-shadow: 0 8px 28px rgba(0,0,0,.35);
       overflow: visible;
@@ -154,6 +158,7 @@
       position: absolute;
       inset: 0;
       backface-visibility: hidden;
+      -webkit-backface-visibility: hidden;
       border-radius: 12px;
       display: flex;
       align-items: flex-start;
@@ -164,7 +169,10 @@
       background-image: var(--bg-url);
     }
 
-    .face.back { transform: rotateY(180deg); }
+    .face.back {
+      transform: rotateY(180deg);
+      -webkit-transform: rotateY(180deg);
+    }
 
     .text-frame {
       position: absolute;


### PR DESCRIPTION
## Summary
- add WebKit-prefixed perspective and transform-style properties so the scene renders correctly in Safari
- add WebKit-prefixed transitions and backface handling so the festival pass flip animation behaves on iOS

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd65c7df708331a66f732840ff6b89