### PR TITLE
Adjust festival info text frame spacing

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -168,12 +168,12 @@
 
     .text-frame {
       position: absolute;
-      top: 36%;
-      bottom: 16%;
-      left: 28%;
-      right: 28%;
+      top: 37%;
+      bottom: 18%;
+      left: 29%;
+      right: 29%;
       overflow: hidden;
-      padding: clamp(8px, 1.1vw, 12px);
+      padding: clamp(10px, 1.25vw, 14px);
       border-radius: 8px;
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
       overflow-wrap: break-word;


### PR DESCRIPTION
## Summary
- pull the festival info text frame further inside the printed border on both pass faces
- increase the text frame padding clamp for extra breathing room

## Testing
- Manual preview in browser (desktop/mobile)

------
https://chatgpt.com/codex/tasks/task_e_68dd65c9482083319154a03f58ad1bbb