### PR TITLE
Improve WebKit support for festival pass flip

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -113,8 +113,9 @@
       max-width: 720px;
       max-height: 90vh;
       aspect-ratio: 1220 / 2126;
-      perspective: 1200px;
+      /* WebKit needs the prefixed perspective for 3D on iOS */
       -webkit-perspective: 1200px;
+      perspective: 1200px;
       cursor: pointer;
       display: flex;
       align-items: stretch;
@@ -142,8 +143,9 @@
       max-height: 100%;
       aspect-ratio: inherit;
       position: relative;
-      transform-style: preserve-3d;
+      /* Preserve depth on the pass for Safari */
       -webkit-transform-style: preserve-3d;
+      transform-style: preserve-3d;
       transition: transform 700ms cubic-bezier(.2,.9,.3,1);
       -webkit-transition: -webkit-transform 700ms cubic-bezier(.2,.9,.3,1);
       border-radius: 12px;
@@ -157,8 +159,9 @@
     .face {
       position: absolute;
       inset: 0;
-      backface-visibility: hidden;
+      /* Hide faces during the flip on Safari */
       -webkit-backface-visibility: hidden;
+      backface-visibility: hidden;
       border-radius: 12px;
       display: flex;
       align-items: flex-start;
@@ -170,8 +173,8 @@
     }
 
     .face.back {
-      transform: rotateY(180deg);
       -webkit-transform: rotateY(180deg);
+      transform: rotateY(180deg);
     }
 
     .text-frame {


### PR DESCRIPTION
## Summary
- document and reorder the festival pass 3D flip styles so the Safari-prefixed rules are applied reliably

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd68b207588331a2b60439de8ad03d