### PR TITLE
Improve mobile festival info pass scrolling

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -183,13 +183,24 @@
       bottom: 18%;
       left: 29%;
       right: 29%;
-      overflow: hidden;
       padding: clamp(10px, 1.25vw, 14px);
       border-radius: 8px;
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+      overflow-x: hidden;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
       overflow-wrap: break-word;
       word-break: break-word;
       max-height: 100%;
+    }
+
+    @media (max-width: 480px) {
+      .text-frame {
+        top: 32%;
+        bottom: 12%;
+        left: 22%;
+        right: 22%;
+      }
     }
 
     h2, h3 {


### PR DESCRIPTION
## Summary
- allow the festival info pass text frame to scroll vertically on touch devices without changing desktop behaviour
- adjust the text frame offsets on very small viewports so the travel information fits inside the pass

## Testing
- Manually verified festival-info.html at 320px, 375px, and 1280px viewports via Playwright screenshots

------
https://chatgpt.com/codex/tasks/task_e_68dd6b6bc5b883318a0790ec82ee702b