### PR TITLE
Restyle festival pass flip control

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -183,13 +183,95 @@
       bottom: 18%;
       left: 29%;
       right: 29%;
-      overflow: hidden;
       padding: clamp(10px, 1.25vw, 14px);
       border-radius: 8px;
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
+      overflow-x: hidden;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
       overflow-wrap: break-word;
       word-break: break-word;
       max-height: 100%;
+    }
+
+    .flip-cta {
+      position: absolute;
+      left: 50%;
+      bottom: clamp(46px, 9%, 100px);
+      width: min(60%, 320px);
+      transform: translateX(-50%);
+      display: flex;
+      justify-content: center;
+      z-index: 4;
+    }
+
+    .flip-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: clamp(6px, 1vw, 10px);
+      padding: clamp(10px, 1.5vw, 16px) clamp(22px, 3.5vw, 32px);
+      font-family: Impact, 'Haettenschweiler', 'Arial Black', sans-serif;
+      font-size: clamp(0.65rem, calc(0.2rem + 1.1vw), 0.95rem);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      text-align: center;
+      color: #1a0120;
+      background-image:
+        repeating-linear-gradient(-45deg, rgba(255, 255, 255, 0.18) 0 8px, transparent 8px 16px),
+        linear-gradient(180deg, #fef7ba 0%, #f5c54f 100%);
+      border: 2px solid #1a0120;
+      border-radius: 999px;
+      box-shadow: 0 6px 0 rgba(26, 1, 32, 0.38), 0 12px 22px rgba(0, 0, 0, 0.28);
+      cursor: pointer;
+      text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      -webkit-backface-visibility: hidden;
+      backface-visibility: hidden;
+    }
+
+    .flip-button::after {
+      content: '\21BB';
+      font-size: 1.35em;
+      line-height: 1;
+    }
+
+    .face.back .flip-button::after {
+      content: '\21BA';
+    }
+
+    .flip-button:focus-visible {
+      outline: 3px solid rgba(255, 255, 255, 0.85);
+      outline-offset: 3px;
+    }
+
+    .flip-button:hover {
+      transform: translateY(1px);
+      box-shadow: 0 5px 0 rgba(26, 1, 32, 0.3), 0 8px 18px rgba(0, 0, 0, 0.24);
+    }
+
+    .flip-button:active {
+      transform: translateY(3px);
+      box-shadow: 0 2px 0 rgba(26, 1, 32, 0.32), 0 4px 12px rgba(0, 0, 0, 0.2);
+    }
+
+    @media (max-width: 480px) {
+      .text-frame {
+        top: 32%;
+        bottom: 12%;
+        left: 22%;
+        right: 22%;
+      }
+
+      .flip-cta {
+        width: min(68%, 260px);
+        bottom: clamp(32px, 7.5%, 70px);
+      }
+
+      .flip-button {
+        padding: clamp(9px, 2.6vw, 14px) clamp(18px, 5vw, 28px);
+        font-size: clamp(0.58rem, 4vw, 0.8rem);
+      }
     }
 
     h2, h3 {
@@ -227,32 +309,6 @@
     strong {
       font-weight: 600;
       color: #12030f;
-    }
-
-    .hint {
-      position: absolute;
-      left: 12px;
-      top: 12px;
-      background: rgba(255,255,255,0.85);
-      color: #2a1a1a;
-      font-size: 11px;
-      padding: 6px 10px;
-      border-radius: 999px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.12);
-      user-select: none;
-      display: none;
-    }
-
-    @media(min-width:680px) {
-      .hint { display: block; }
-      .hint-back { display: block; }
-    }
-
-    .hint-back {
-      right: 12px;
-      left: auto;
-      top: 12px;
-      display: none;
     }
 
     .pass, .text-frame, .face { -webkit-user-select: none; -ms-user-select: none; user-select: none; }
@@ -314,39 +370,6 @@
     .site-footer .attribution { font-size: 10px; margin-top:6px; color: #30997a; }
     .site-footer .attribution a { color: #30997a; text-decoration:none; }
 		
-		/* Show flip hint on mobile and keep the desktop behaviour */
-		.hint,
-		.hint-back {
-			display: block !important;        /* make visible on all viewports */
-			position: absolute;
-			top: 12px;
-			left: 12px;
-			right: auto;
-			background: rgba(255,255,255,0.9);
-			color: #2a1a1a;
-			font-size: 11px;
-			padding: 6px 10px;
-			border-radius: 999px;
-			box-shadow: 0 2px 6px rgba(0,0,0,0.12);
-			z-index: 10;
-			pointer-events: none;             /* won't block taps on the scene */
-			-webkit-user-select: none;
-			user-select: none;
-		}
-
-		/* Keep the back hint on the right */
-		.hint-back { left: auto; right: 12px; }
-
-		/* Slightly reduce size and spacing on very small screens */
-		@media (max-width: 420px) {
-			.hint,
-			.hint-back {
-				font-size: 10px;
-				padding: 5px 8px;
-				top: 8px;
-			}
-		}
-
   </style>
 </head>
 <body>
@@ -422,11 +445,10 @@
     <div class="lanyard">
       <div class="lanyard-strap" aria-hidden="true"></div>
       <div class="lanyard-clip" aria-hidden="true"></div>
-      <div class="scene" id="scene" tabindex="0" aria-label="Festival pass. Click to flip for more information.">
+      <div class="scene" id="scene" tabindex="0" aria-label="Festival pass. Use the Flip button below or click or tap anywhere to see more information.">
         <div class="pass" id="pass">
 
         <section class="face front" aria-hidden="false">
-          <div class="hint">Click to flip</div>
           <div class="text-frame" id="frontText">
             <h2>FESTIVAL INFORMATION</h2>
             <p>The sections below aim to give you all the information you need about Whelnett Wedfest.</p>
@@ -441,10 +463,13 @@
             <p><strong>Cycle:</strong> If you are feeling adventurous, Poplar Farm is along National Cycle Route 33. North Somerset has some beautiful countryside to explore along the cycle routes.</p>
             <p><strong>Taxis:</strong> We would advise to book a taxi or Uber in advance as they are not frequent in the area. Local Companies: North Somerset Taxis, Streets Ahead Taxis, Triangle Cars Clevedon</p>
           </div>
+
+          <div class="flip-cta">
+            <button class="flip-button" type="button">Flip for more info</button>
+          </div>
         </section>
 
         <section class="face back" aria-hidden="true">
-          <div class="hint hint-back">Click to flip</div>
           <div class="text-frame" id="backText">
             <h3>Accommodation</h3>
             <p>If camping or even glamping isn’t your style, Poplar Farm is not far from Clevedon or Yatton for hotels and AirBnBs. <br> We highly encourage you to bring the festival vibes though and rent a bell tent! <br> See our glamping options page for more information on what to expect.</p>
@@ -454,6 +479,10 @@
 
             <h3>Contacts</h3>
             <p>Any queries, whatsapp Hannah or Laurie.</p>
+          </div>
+
+          <div class="flip-cta">
+            <button class="flip-button" type="button">Flip back to front</button>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- replace the old corner hint with a themed flip button that matches the festival styling
- center the new control inside the pass footer on both sides and tune its sizing for mobile viewports
- refresh the pass aria label to mention the relocated button

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6b6bc5b883318a0790ec82ee702b