### PR TITLE
Update flip toggle styling to use shared theme

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -244,21 +244,36 @@
       position: absolute;
       left: 12px;
       top: 12px;
-      background: rgba(255,255,255,0.85);
-      color: #2a1a1a;
+      background: var(--brand);
+      color: var(--nav-text);
       font-size: 11px;
       padding: 6px 10px;
       border-radius: 999px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.12);
       user-select: none;
       display: none;
-      border: 0;
+      border: 2px solid var(--accent);
       font-family: inherit;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
       line-height: 1.2;
       cursor: pointer;
       pointer-events: auto;
       appearance: none;
       background-clip: padding-box;
+    }
+
+    .flip-toggle:hover,
+    .flip-toggle:focus-visible {
+      background: var(--accent);
+      color: var(--brand);
+      border-color: var(--brand);
+    }
+
+    .flip-toggle:focus-visible {
+      outline: 3px solid var(--nav-text);
+      outline-offset: 3px;
     }
 
     @media(min-width:680px) {


### PR DESCRIPTION
## Summary
- restyled the festival info flip toggle buttons to use the shared brand colors and typography
- added hover and focus-visible states that lighten the buttons and provide a clear focus outline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda939437483318b45dd0206885315