### PR TITLE
Restore brand styling for flip hint buttons

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -355,16 +355,7 @@
                         top: 12px;
                         left: 12px;
                         right: auto;
-                        background: rgba(255,255,255,0.9);
-                        color: #2a1a1a;
-                        font-size: 11px;
-                        padding: 6px 10px;
-                        border-radius: 999px;
-                        box-shadow: 0 2px 6px rgba(0,0,0,0.12);
                         z-index: 10;
-                        pointer-events: auto;
-                        -webkit-user-select: none;
-                        user-select: none;
                 }
 
                 /* Keep the back hint on the right */
@@ -374,8 +365,6 @@
                 @media (max-width: 420px) {
                         .flip-toggle,
                         .hint-back {
-                                font-size: 10px;
-                                padding: 5px 8px;
                                 top: 8px;
                         }
                 }


### PR DESCRIPTION
## Summary
- remove the mobile override that was redefining background, text color, and other styling for the flip controls
- keep only the visibility and positioning tweaks so the shared theme styling remains in place on all viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddab4ce7e48331af4a49b1304cc9af