### PR TITLE
Adjust festival info typography for readability

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -204,7 +204,7 @@
     }
 
     h2, h3 {
-      margin-bottom: 0.18rem;
+      margin-bottom: 0.35rem;
       line-height: 1.1;
       font-family: Impact, 'Haettenschweiler', 'Arial Black', sans-serif;
       color: #1a0120;
@@ -212,21 +212,21 @@
     }
 
       h2 {
-        font-size: clamp(0.7rem, 1.5vw, 0.85rem);
+        font-size: clamp(0.85rem, 2vw, 1.05rem);
         text-align: center;
         text-transform: uppercase;
         letter-spacing: 0.04em;
       }
 
       h3 {
-        font-size: clamp(0.55rem, 1.2vw, 0.7rem);
+        font-size: clamp(0.82rem, 1.8vw, 1rem);
         margin-top: 0.4rem;
       }
 
       p {
-        font-size: clamp(0.48rem, 1vw, 0.65rem);
-        line-height: 1.15;
-        margin-top: 0.18rem;
+        font-size: clamp(0.68rem, 1.4vw, 0.78rem);
+        line-height: 1.4;
+        margin: 0.2rem 0 0.35rem;
         color: #12030f;
       }
 


### PR DESCRIPTION
## Summary
- enlarge festival info heading typography to around 1rem desktop while maintaining mobile readability
- increase paragraph size and line height for improved legibility
- add consistent spacing after headings and paragraphs to separate section entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddac95569c8331bb64d4d747461786