### PR TITLE
Style text frame scrollbars

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -189,10 +189,16 @@
       overflow-x: hidden;
       overflow-y: auto;
       -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin;
+      scrollbar-color: #000000 transparent;
       overflow-wrap: break-word;
       word-break: break-word;
       max-height: 100%;
     }
+
+    .text-frame::-webkit-scrollbar { width: 3px; }
+    .text-frame::-webkit-scrollbar-track { background: transparent; }
+    .text-frame::-webkit-scrollbar-thumb { background-color: #000; border-radius: 999px; }
 
     @media (max-width: 480px) {
       .text-frame {


### PR DESCRIPTION
## Summary
- add cross-browser scrollbar styling to the festival info pass text frame
- include WebKit-specific scrollbar overrides for consistent appearance

## Testing
- playwright screenshot of festival-info.html at desktop viewport
- playwright screenshot of festival-info.html at tablet viewport
- playwright screenshot of festival-info.html at mobile viewport

------
https://chatgpt.com/codex/tasks/task_e_68ddb4c5563083318667cdd90c94d39a