### PR TITLE
Prevent text frame clicks from flipping pass

### DIFF
--- a/festival-info.html
+++ b/festival-info.html
@@ -125,6 +125,8 @@
       -webkit-transform-style: preserve-3d;
     }
 
+    .scene .text-frame { cursor: text; }
+
     @media (max-width: 600px) {
       .lanyard {
         --lanyard-drop: clamp(110px, 24vh, 180px);
@@ -638,7 +640,12 @@
         updateToggleState();
       }
 
-      scene.addEventListener('click', toggleFlip);
+      scene.addEventListener('click', function(event){
+        if (event.target.closest('.text-frame')) {
+          return;
+        }
+        toggleFlip(event);
+      });
 
       toggles.forEach(function(btn){
         btn.addEventListener('click', function(event){


### PR DESCRIPTION
## Summary
- ignore clicks originating from within the pass text frames so reading the FAQ no longer flips the pass unintentionally
- keep the dedicated flip buttons working while ensuring text areas show a text cursor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de57c604e88331aba69fa84572975a